### PR TITLE
Use mixins instead of prefixes

### DIFF
--- a/style/mixins.less
+++ b/style/mixins.less
@@ -1,0 +1,43 @@
+.transform (@transformation) {
+  -webkit-transform: @transformation;
+  -moz-transform: @transformation;
+  -ms-transform: @transformation;
+  -o-transform: @transformation;
+  transform: @transformation;
+}
+
+.scaleX (@factor) {
+  -webkit-transform: scaleX(@factor);
+  -moz-transform: scaleX(@factor);
+  -ms-transform: scaleX(@factor);
+  -o-transform: scaleX(@factor);
+  transform: scaleX(@factor);
+}
+
+.rotate (@deg) {
+  -webkit-transform: rotate(@deg);
+  -moz-transform: rotate(@deg);
+  -ms-transform: rotate(@deg);
+  -o-transform: rotate(@deg);
+  transform: rotate(@deg);
+}
+
+.box-shadow (@val) {
+  -webkit-box-shadow: @val;
+  -moz-box-shadow: @val;
+  box-shadow: @val;
+}
+
+.border-radius (@radius: 5px) {
+  -webkit-border-radius: @radius;
+  -moz-border-radius: @radius;
+  border-radius: @radius;
+}
+
+.gradient (@color1, @color2 ) {
+  background: -moz-linear-gradient(top, @color1 0%, @color2 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,@color1), color-stop(100%,@color2));
+  background: -webkit-linear-gradient(top, @color1 0%,@color2 100%);
+  background: -o-linear-gradient(top, @color1 0%,@color2 100%);
+  background: linear-gradient(to bottom, @color1 0%,@color2 100%);
+}

--- a/style/print.less
+++ b/style/print.less
@@ -1,3 +1,5 @@
+@import (reference) "style/mixins.less";
+
 body {
   margin:0;
   padding:0;
@@ -67,29 +69,17 @@ header,
     margin-right:-75px !important;
   }
   .rot1 {
-    -moz-transform: rotate(90deg);
-    -webkit-transform: rotate(90deg);
-    -o-transform:rotate(90deg);
-    -ms-transform: rotate(90deg);
-    transform: rotate(90deg);
+    .rotate(90deg);
     -ms-filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
     filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
   }
   .rot2 {
-    -moz-transform: rotate(180deg);
-    -webkit-transform: rotate(180deg);
-    -o-transform:rotate(180deg);
-    -ms-transform: rotate(180deg);
-    transform: rotate(180deg);
+    .rotate(180deg);
     -ms-filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
     filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
   }
   .rot3 {
-    -moz-transform: rotate(270deg);
-    -webkit-transform: rotate(270deg);
-    -o-transform:rotate(270deg);
-    -ms-transform: rotate(270deg);
-    transform: rotate(270deg);
+    .rotate(270deg);
     -ms-filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
     filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   }
@@ -103,20 +93,12 @@ header,
   }
   .rot1,
   .rot3 {
-    -webkit-transform:scaleX(-1);
-    -moz-transform:scaleX(-1);
-    -ms-transform:scaleX(-1);
-    -o-transform:scaleX(-1);
-    transform:scaleX(-1);
+    .scaleX(-1);
     filter:fliph;
   }
   .rot0,
   .rot2 {
-    -webkit-transform:none;
-    -moz-transform:none;
-    -ms-transform:none;
-    -o-transform:none;
-    transform:none;
+    .transform(none);
     filter:none;
   }
 }

--- a/style/print.less
+++ b/style/print.less
@@ -70,18 +70,12 @@ header,
   }
   .rot1 {
     .rotate(90deg);
-    -ms-filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
-    filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
   }
   .rot2 {
     .rotate(180deg);
-    -ms-filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
-    filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
   }
   .rot3 {
     .rotate(270deg);
-    -ms-filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
-    filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   }
 }
 
@@ -94,11 +88,9 @@ header,
   .rot1,
   .rot3 {
     .scaleX(-1);
-    filter:fliph;
   }
   .rot0,
   .rot2 {
     .transform(none);
-    filter:none;
   }
 }

--- a/style/style.less
+++ b/style/style.less
@@ -1177,17 +1177,14 @@ aside.widget ul li ul.children li a{
 
   .rot1{
     .rotate(90deg);
-    filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
   }
 
   .rot2{
     .rotate(180deg);
-    filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
   }
 
   .rot3{
     .rotate(270deg);
-    filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   }
 }
 
@@ -1202,11 +1199,9 @@ aside.widget ul li ul.children li a{
   }
   .rot1,.rot3{
     .scaleX(-1);
-    filter:fliph;
   }
   .rot0,.rot2{
     .transform(none);
-    filter:none;
   }
 }
 
@@ -1510,8 +1505,6 @@ table{
 .ui-tooltip-tipped .ui-tooltip-titlebar,
 .ui-tooltip-tipped .ui-tooltip-content{
   border:3px solid #959FA9;
-  filter:none;
-  -ms-filter:none;
 }
 .ui-tooltip-tipped .ui-tooltip-titlebar{
   background:#3A79B8;
@@ -1534,11 +1527,6 @@ table{
 .ui-tooltip-tipped .ui-tooltip-icon .ui-icon{
   background-color:#FBFBFB;
   color:#555;
-}
-.ui-tooltip:not(.ie9haxors) div.ui-tooltip-content,
-.ui-tooltip:not(.ie9haxors) div.ui-tooltip-titlebar{
-  filter:none;
-  -ms-filter:none;
 }
 
 .sprite{

--- a/style/style.less
+++ b/style/style.less
@@ -1,3 +1,5 @@
+@import (reference) "style/mixins.less";
+
 @darkbrown: #321;
 @medbrown: #642;
 @litebrown: #963;
@@ -20,6 +22,8 @@
 @popup: 200;
 
 @masthead: 500;
+
+
 
 .content-box{
   -webkit-box-sizing:content-box;
@@ -51,25 +55,6 @@
   font-family:'Philosopher', Arial, sans-serif;
 }
 
-.box-shadow (@val) {
-  -webkit-box-shadow: @val;
-  -moz-box-shadow: @val;
-  box-shadow: @val;
-}
-
-.border-radius (@radius: 5px) {
-  -webkit-border-radius: @radius;
-  -moz-border-radius: @radius;
-  border-radius: @radius;
-}
-
-.gradient (@color1, @color2 ) {
-  background: -moz-linear-gradient(top, @color1 0%, @color2 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,@color1), color-stop(100%,@color2));
-  background: -webkit-linear-gradient(top, @color1 0%,@color2 100%);
-  background: -o-linear-gradient(top, @color1 0%,@color2 100%);
-  background: linear-gradient(to bottom, @color1 0%,@color2 100%);
-}
 
 html,body{
   height:100%;
@@ -1191,27 +1176,17 @@ aside.widget ul li ul.children li a{
   }
 
   .rot1{
-    -moz-transform:rotateZ(90deg);
-    -webkit-transform:rotateZ(90deg);
-    -o-transform:rotateZ(90deg);
-    -ms-transform:rotateZ(90deg);
-    transform:rotateZ(90deg);
+    .rotate(90deg);
     filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
   }
+
   .rot2{
-    -moz-transform:rotateZ(180deg);
-    -webkit-transform:rotateZ(180deg);
-    -o-transform:rotateZ(180deg);
-    -ms-transform:rotateZ(180deg);
-    transform:rotateZ(180deg);
+    .rotate(180deg);
     filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
   }
+
   .rot3{
-    -moz-transform:rotateZ(270deg);
-    -webkit-transform:rotateZ(270deg);
-    -o-transform:rotateZ(270deg);
-    -ms-transform:rotateZ(270deg);
-    transform:rotateZ(270deg);
+    .rotate(270deg);
     filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
   }
 }
@@ -1226,19 +1201,11 @@ aside.widget ul li ul.children li a{
     }
   }
   .rot1,.rot3{
-    -webkit-transform:scaleX(-1);
-    -moz-transform:scaleX(-1);
-    -ms-transform:scaleX(-1);
-    -o-transform:scaleX(-1);
-    transform:scaleX(-1);
+    .scaleX(-1);
     filter:fliph;
   }
   .rot0,.rot2{
-    -webkit-transform:none;
-    -moz-transform:none;
-    -ms-transform:none;
-    -o-transform:none;
-    transform:none;
+    .transform(none);
     filter:none;
   }
 }


### PR DESCRIPTION
Created a mixins.less that's imported by reference to both style.less and print.less.

I kept the `filter` and other old MS hacks intact (maybe consider removing them altogether, they are only required for IE <9, which has an usage stat of ~0.5%).

Resolves #43 